### PR TITLE
Allow NameIDType objects to be seen in a JSON output

### DIFF
--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -15,7 +15,7 @@ use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
 use Serializable;
 
-abstract class NameIDType implements Serializable
+abstract class NameIDType implements Serializable, \JsonSerializable
 {
     use IDNameQualifiersTrait;
 
@@ -266,5 +266,20 @@ abstract class NameIDType implements Serializable
         $ele = $this->toXML($root);
 
         return $doc->saveXML($ele);
+    }
+
+
+    /**
+     * Because we have mostly protected attributes we do not look
+     * interesting when converted into JSON. This allows for good
+     * visibility from JSON which is used on the admin/test login page
+     * when showing the attributes for the user.
+     *
+     * @return array associative array of defined object accessible
+     * non-static properties for the specified object in scope.
+     */
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
     }
 }

--- a/src/SAML2/XML/saml/NameIDType.php
+++ b/src/SAML2/XML/saml/NameIDType.php
@@ -14,6 +14,7 @@ use DOMElement;
 use SAML2\Constants;
 use SAML2\DOMDocumentFactory;
 use Serializable;
+use JsonSerializable;
 
 abstract class NameIDType implements Serializable, \JsonSerializable
 {


### PR DESCRIPTION
The admin/test page converts the object to JSON and objects with protected attributes to not get shown. This allows those objects to appear on the debug page.

This will also allow the contents of NameIDTypes to be seen in any JSON serialization. So if there are thing that we want to mask for any reason then we should look deeper into this. Though if that is the case then the code calling json_encode should itself probably be copying and scrubbing the data to serialize if there are things we do not want to have in the output.